### PR TITLE
Update README.md to point the Python 3.10 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Due to licensing restraints, Eupnea cannot be distributed as an iso. Instead, it
 * Developer mode enabled on your chromebook([How to enable developer mode](https://www.androidauthority.com/how-to-enable-developer-mode-on-a-chromebook-906688/))
 * A USB-stick or SD-card with 12GB of storage
 * IF not using direct write: 10GB of free space on the "builder" device
+* Python 3.10 is required for running the `build.py` script
 
 ## Instructions:
 


### PR DESCRIPTION
Eupnea fails to run if Python 3.10 is unavailable. This must be warned since `crostini` does not even have Python 3.10; only 3.9 is available by default.