### PR TITLE
Add dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Due to licensing restraints, Eupnea cannot be distributed as an iso. Instead, it
     
 4. [Enable Devloper mode](https://www.androidauthority.com/how-to-enable-developer-mode-on-a-chromebook-906688/) now, if you havent done so yet.
 
-5. Boot into ChromeOS, open the shell by pressing <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>T</kbd>, enter `shell` and press <kbd>Enter</kbd>.  
+5. Boot into ChromeOS, open the shell by pressing <kbd>CTRL</kbd><kbd>ALT</kbd><kbd>T</kbd>, enter `shell` and press <kbd>Enter</kbd>.  
 
 6. Inside the chromeos shell enable USB and Custom Kernel Booting by running:
     ```
     sudo crossystem dev_boot_usb=1; sudo crossystem dev_boot_signed_only=0; sync
     ```
 
-7. Reboot with the USB plugged in and press <kbd>CTRL</kbd>+<kbd>U</kbd> or select "External". 
+7. Reboot with the USB plugged in and press <kbd>CTRL</kbd><kbd>U</kbd> or select "External". 
 
 After a short black screen Eupnea should boot.
 

--- a/docs.html
+++ b/docs.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <meta name="color-scheme" content="dark light">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css">
   <link rel="stylesheet" href="stylesheet.css">
 </head>

--- a/homepage.css
+++ b/homepage.css
@@ -1,0 +1,34 @@
+#laptop {
+    max-width: 75%;
+    height: auto;
+    text-align: center;
+}
+
+html, body {
+    max-width: 100% !important;
+    overflow-x: hidden !important;
+}
+
+svg {
+    fill: var(--bs-dark);
+}
+
+@media screen and (prefers-color-scheme: dark) {
+    :root {
+        --bs-light-rgb: 30,30,30;
+        --bs-dark-rgb: 200,200,200;
+        --bs-light: rgb(var(--bs-light-rgb));
+        --bs-dark: rgb(var(--bs-dark-rgb));
+        --bs-body-bg: #111;
+        --bs-body-color: var(--bs-dark);
+        --bs-border-color: #777;
+    }
+
+    .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
+        color: #fff;
+    }
+
+    .text-muted {
+        color: #aaa !important;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -11,20 +11,7 @@
     <link rel="stylesheet" href="https://unpkg.com/bootstrap@5.1.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://bootswatch.com/5/zephyr/bootstrap.min.css">
     <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
-    
-    <style>
-        #laptop {
-            max-width: 75%;
-            height: auto;
-            text-align: center;
-        }
-
-        html, body {
-            max-width: 100% !important;
-            overflow-x: hidden !important;
-        }
-    </style>
-
+    <link rel="stylesheet" href="homepage.css">
 </head>
 
 <body>
@@ -34,7 +21,9 @@
             <a href="https://github.com/eupnea-linux/eupnea"
                class="d-flex align-items-center text-dark text-decoration-none">
                 <span class="fs-4 flex-grow-1">Eupnea</span>
-                <img width="50px" src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="Github Icon"></img>
+                <svg width="50px" viewBox="-2 -2 20 20" version="1.1">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
             </a>
         </header>
 

--- a/pages/crostini.md
+++ b/pages/crostini.md
@@ -6,7 +6,7 @@ Due to the way Crostini is set up, the container needs to be started with specia
 ## Instructions:  
 (How to run a command: Copy the ``command`` into the terminal and press <kbd>Enter</kbd>)
 
-1. <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>T</kbd>, enter `shell` and press <kbd>Enter</kbd>  
+1. <kbd>CTRL</kbd><kbd>ALT</kbd><kbd>T</kbd>, enter `shell` and press <kbd>Enter</kbd>  
 2. ``vmc stop termina``
 3. ``vmc start termina``
 4. ``exit``

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -21,6 +21,7 @@
     --base-background-color: #f2f2f2;
     --sidebar-toggle-background: rgba(255, 255, 255, 0);
     --code-theme-background: #ebebeb;
+    --sidebar-soft-shadow: #cecece3e;
 }
 
 .sidebar-nav p * {
@@ -33,8 +34,8 @@
 }
 
 .sidebar {
-    box-shadow: 20px 20px 60px #cecece3e,
-                -20px -20px 60px #ffffff;
+    box-shadow: 20px 20px 60px var(--sidebar-soft-shadow),
+                -20px -20px 60px var(--base-background-color);
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
     scrollbar-width: none;  /* Firefox */
 }
@@ -47,14 +48,27 @@
     padding-top: 3.5rem;
 }
 
-body {
-  background-color: black;
-  color: white;
-}
-
-@media screen and (prefers-color-scheme: light) {
-  body {
-    background-color: white;
-    color: black;
+@media screen and (prefers-color-scheme: dark) {
+  :root {
+    --theme-color: #73a6e0;
+    --base-background-color: #111;
+    --base-color: #bbb;
+    --heading-color: #fff;
+    --link-color: #eee;
+    --selection-color: #374c64;
+    --sidebar-background: #1a1a1a;
+    --sidebar-border-color: #333;
+    --sidebar-soft-shadow: #1114;
+    --sidebar-nav-link-color: var(--base-color);
+    --code-theme-background: #2a2a2a;
+    --code-theme-text: #fff;
+    --code-inline-background: #2a2a2a;
+    --code-inline-color: #ddd;
+    --copycode-background: #222;
+    --copycode-color: #fff;
+    --kbd-background: #111;
+    --kbd-border: 1px solid var(--mono-tint1);
+    --blockquote-background: #1a1a1a;
+    --blockquote-border-color: #777;
   }
 }


### PR DESCRIPTION
This PR adds dark styling to the website (if the visitor's system prefers dark mode). Because the homepage (which uses Bootstrap) is built different from the generated doc pages, support for it will arrive in a later commit.

**Implemented changes**
- [x] Dark mode for docs
- [x] Dark mode for homepage

**Side note**: Docs are generated and served using the npm package [docsify](https://docsify.js.org/). By installing the package and running `docsify serve` in your repository root, you can visit `localhost:3000/docs.html` to view the doc pages and see changes made to the stylesheet in realtime.