### PR TITLE
Fix broken faq redirection for firmware-comparison.md

### DIFF
--- a/docs/chromebook/firmware-comparison.md
+++ b/docs/chromebook/firmware-comparison.md
@@ -10,7 +10,7 @@ you decide which method is best for you.
         * Offers Gnome, KDE, XFCE, LXDE, Deepin, Budgie and a cli version as desktop environments
     * Cons:
         * Can only be used on x86_64 Chromebooks with depthcharge
-        * Has to be built locally ([why?](/docs/extra/faq#why-is-sharing-depthboot-images-illegal))
+        * Has to be built locally ([why?](/faq#why-is-sharing-depthboot-images-illegal))
         * May take a long time to build on weaker Chromebooks
 * EupneaOS
     * Pros:


### PR DESCRIPTION
In firmware-comparison.md, the redirection to the faq section "Why is sharing Depthboot images illegal?" is broken and instead takes you to an 404 page. This pull request attempts to fix it